### PR TITLE
Correct TLS version bug that prevents SSL from connecting

### DIFF
--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -725,7 +725,7 @@ execute_request(ServiceContext = #service_context{}, ReqContext = #req_context{}
 
         Response = httpc:request(ReqContext#req_context.method,
                                  erlazure_http:create_request(ReqContext, [AuthHeader | Headers1]),
-                                 [{version, "HTTP/1.1"}],
+                                 [{version, "HTTP/1.1"}, {ssl, [{versions, ['tlsv1.2']}]}],
                                  [{sync, true}, {body_format, binary}, {headers_as_is, true}]),
         case Response of
           {ok, {{_, Code, _}, _, Body}}


### PR DESCRIPTION
This is due to a bug in some erlang versions apparently. Without the specified TLS version used by azure, the SSL handshake fails.

[Bug](https://bugs.erlang.org/browse/ERL-192
)