### PR TITLE
Adds error handling for unexpected responses for create/update/acquir…

### DIFF
--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -344,8 +344,13 @@ handle_call({set_queue_acl, Queue, SignedId=#signed_id{}, Options}, _From, State
                       {params, [{comp, acl}] ++ Options}],
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_no_content, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_no_content ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Get queue acl
 handle_call({get_queue_acl, Queue, Options}, _From, State) ->
@@ -382,8 +387,13 @@ handle_call({delete_queue, Queue, Options}, _From, State) ->
                       {params, Options}],
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_no_content, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, deleted}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_no_content ->
+            {reply, {ok, deleted}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Add message to a queue
 handle_call({put_message, Queue, Message, Options}, _From, State) ->
@@ -394,8 +404,13 @@ handle_call({put_message, Queue, Message, Options}, _From, State) ->
                       {params, Options}],
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_created, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_created ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Get messages from the queue
 handle_call({get_messages, Queue, Options}, _From, State) ->
@@ -425,8 +440,13 @@ handle_call({delete_message, Queue, MessageId, PopReceipt, Options}, _From, Stat
                       {params, [{pop_receipt, PopReceipt}] ++ Options}],
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_no_content, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, deleted}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_no_content ->
+            {reply, {ok, deleted}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Delete all messages from the queue
 handle_call({clear_messages, Queue, Options}, _From, State) ->
@@ -436,8 +456,13 @@ handle_call({clear_messages, Queue, Options}, _From, State) ->
                       {params, Options}],
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_no_content, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, deleted}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_no_content ->
+            {reply, {ok, deleted}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Update a message in the queue
 handle_call({update_message, Queue, UpdatedMessage=#queue_message{}, VisibilityTimeout, Options}, _From, State) ->
@@ -450,8 +475,13 @@ handle_call({update_message, Queue, UpdatedMessage=#queue_message{}, VisibilityT
                       {params, Params ++ Options}],
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_no_content, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, updated}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_no_content ->
+            {reply, {ok, updated}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % List containers
 handle_call({list_containers, Options}, _From, State) ->
@@ -484,8 +514,13 @@ handle_call({delete_container, Name, Options}, _From, State) ->
                       {params, [{res_type, container}] ++ Options}],
         RequestContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_accepted, _Body} = execute_request(ServiceContext, RequestContext),
-        {reply, {ok, deleted}, State};
+        {Code, Body} = execute_request(ServiceContext, RequestContext),
+        case Code of
+          ?http_accepted ->
+            {reply, {ok, deleted}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Lease a container
 handle_call({lease_container, Name, Mode, Options}, _From, State) ->
@@ -498,8 +533,13 @@ handle_call({lease_container, Name, Mode, Options}, _From, State) ->
                       {params, Params ++ Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_accepted, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, deleted}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_accepted ->
+            {reply, {ok, deleted}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % List blobs
 handle_call({list_blobs, Name, Options}, _From, State) ->
@@ -527,8 +567,13 @@ handle_call({put_blob, Container, Name, Type = block_blob, Data, Options}, _From
                         ContentType  -> ReqContext#req_context{ content_type = ContentType }
                       end,
 
-        {?http_created, _Body} = execute_request(ServiceContext, ReqContext1),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext1),
+        case Code of
+          ?http_created ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Put page blob
 handle_call({put_blob, Container, Name, Type = page_blob, ContentLength, Options}, _From, State) ->
@@ -540,8 +585,13 @@ handle_call({put_blob, Container, Name, Type = page_blob, ContentLength, Options
                       {params, Params ++ Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_created, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_created ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Get blob
 handle_call({get_blob, Container, Blob, Options}, _From, State) ->
@@ -566,8 +616,13 @@ handle_call({snapshot_blob, Container, Blob, Options}, _From, State) ->
                       {params, [{comp, snapshot}] ++ Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_created, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_created ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Copy blob
 handle_call({copy_blob, Container, Blob, Source, Options}, _From, State) ->
@@ -577,8 +632,13 @@ handle_call({copy_blob, Container, Blob, Source, Options}, _From, State) ->
                       {params, [{blob_copy_source, Source}] ++ Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_accepted, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_accepted ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Delete blob
 handle_call({delete_blob, Container, Blob, Options}, _From, State) ->
@@ -588,8 +648,13 @@ handle_call({delete_blob, Container, Blob, Options}, _From, State) ->
                       {params, Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_accepted, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, deleted}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_accepted ->
+            {reply, {ok, deleted}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Put block
 handle_call({put_block, Container, Blob, BlockId, Content, Options}, _From, State) ->
@@ -602,8 +667,13 @@ handle_call({put_block, Container, Blob, BlockId, Content, Options}, _From, Stat
                       {params, Params ++ Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_created, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_created ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Put block list
 handle_call({put_block_list, Container, Blob, BlockRefs, Options}, _From, State) ->
@@ -614,8 +684,13 @@ handle_call({put_block_list, Container, Blob, BlockRefs, Options}, _From, State)
                       {params, [{comp, "blocklist"}] ++ Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_created, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_created ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Get block list
 handle_call({get_block_list, Container, Blob, Options}, _From, State) ->
@@ -642,8 +717,13 @@ handle_call({acquire_blob_lease, Container, Blob, ProposedId, Duration, Options}
                       {params, Params ++ Options}],
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
-        {?http_created, _Body} = execute_request(ServiceContext, ReqContext),
-        {reply, {ok, acquired}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext),
+        case Code of
+          ?http_created ->
+            {reply, {ok, acquired}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % List tables
 handle_call({list_tables, Options}, _From, State) ->
@@ -663,8 +743,13 @@ handle_call({new_table, TableName}, _From, State) ->
                       {body, jsx:encode([{<<"TableName">>, TableName}])}],
         ReqContext = new_req_context(?table_service, State#state.account, State#state.param_specs, ReqOptions),
         ReqContext1 = ReqContext#req_context{ content_type = ?json_content_type },
-        {?http_created, _} = execute_request(ServiceContext, ReqContext1),
-        {reply, {ok, created}, State};
+        {Code, Body} = execute_request(ServiceContext, ReqContext1),
+        case Code of
+          ?http_created ->
+            {reply, {ok, created}, State};
+          _ ->
+            {reply, {error, Body}, State}
+        end;
 
 % Delete table
 handle_call({delete_table, TableName}, _From, State) ->

--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -345,12 +345,7 @@ handle_call({set_queue_acl, Queue, SignedId=#signed_id{}, Options}, _From, State
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_no_content ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_no_content, created);
 
 % Get queue acl
 handle_call({get_queue_acl, Queue, Options}, _From, State) ->
@@ -388,12 +383,7 @@ handle_call({delete_queue, Queue, Options}, _From, State) ->
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_no_content ->
-            {reply, {ok, deleted}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_no_content, deleted);
 
 % Add message to a queue
 handle_call({put_message, Queue, Message, Options}, _From, State) ->
@@ -405,12 +395,7 @@ handle_call({put_message, Queue, Message, Options}, _From, State) ->
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_created ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, created);
 
 % Get messages from the queue
 handle_call({get_messages, Queue, Options}, _From, State) ->
@@ -441,12 +426,7 @@ handle_call({delete_message, Queue, MessageId, PopReceipt, Options}, _From, Stat
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_no_content ->
-            {reply, {ok, deleted}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_no_content, deleted);
 
 % Delete all messages from the queue
 handle_call({clear_messages, Queue, Options}, _From, State) ->
@@ -457,12 +437,7 @@ handle_call({clear_messages, Queue, Options}, _From, State) ->
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_no_content ->
-            {reply, {ok, deleted}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_no_content, deleted);
 
 % Update a message in the queue
 handle_call({update_message, Queue, UpdatedMessage=#queue_message{}, VisibilityTimeout, Options}, _From, State) ->
@@ -476,12 +451,7 @@ handle_call({update_message, Queue, UpdatedMessage=#queue_message{}, VisibilityT
         ReqContext = new_req_context(?queue_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_no_content ->
-            {reply, {ok, updated}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_no_content, updated);
 
 % List containers
 handle_call({list_containers, Options}, _From, State) ->
@@ -515,12 +485,7 @@ handle_call({delete_container, Name, Options}, _From, State) ->
         RequestContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, RequestContext),
-        case Code of
-          ?http_accepted ->
-            {reply, {ok, deleted}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_accepted, deleted);
 
 % Lease a container
 handle_call({lease_container, Name, Mode, Options}, _From, State) ->
@@ -534,12 +499,7 @@ handle_call({lease_container, Name, Mode, Options}, _From, State) ->
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_accepted ->
-            {reply, {ok, deleted}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_accepted, deleted);
 
 % List blobs
 handle_call({list_blobs, Name, Options}, _From, State) ->
@@ -568,12 +528,7 @@ handle_call({put_blob, Container, Name, Type = block_blob, Data, Options}, _From
                       end,
 
         {Code, Body} = execute_request(ServiceContext, ReqContext1),
-        case Code of
-          ?http_created ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, created);
 
 % Put page blob
 handle_call({put_blob, Container, Name, Type = page_blob, ContentLength, Options}, _From, State) ->
@@ -586,12 +541,7 @@ handle_call({put_blob, Container, Name, Type = page_blob, ContentLength, Options
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_created ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, created);
 
 % Get blob
 handle_call({get_blob, Container, Blob, Options}, _From, State) ->
@@ -617,12 +567,7 @@ handle_call({snapshot_blob, Container, Blob, Options}, _From, State) ->
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_created ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, created);
 
 % Copy blob
 handle_call({copy_blob, Container, Blob, Source, Options}, _From, State) ->
@@ -633,12 +578,7 @@ handle_call({copy_blob, Container, Blob, Source, Options}, _From, State) ->
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_accepted ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_accepted, created);
 
 % Delete blob
 handle_call({delete_blob, Container, Blob, Options}, _From, State) ->
@@ -649,12 +589,7 @@ handle_call({delete_blob, Container, Blob, Options}, _From, State) ->
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_accepted ->
-            {reply, {ok, deleted}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_accepted, deleted);
 
 % Put block
 handle_call({put_block, Container, Blob, BlockId, Content, Options}, _From, State) ->
@@ -668,12 +603,7 @@ handle_call({put_block, Container, Blob, BlockId, Content, Options}, _From, Stat
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_created ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, created);
 
 % Put block list
 handle_call({put_block_list, Container, Blob, BlockRefs, Options}, _From, State) ->
@@ -685,12 +615,7 @@ handle_call({put_block_list, Container, Blob, BlockRefs, Options}, _From, State)
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_created ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, created);
 
 % Get block list
 handle_call({get_block_list, Container, Blob, Options}, _From, State) ->
@@ -718,12 +643,7 @@ handle_call({acquire_blob_lease, Container, Blob, ProposedId, Duration, Options}
         ReqContext = new_req_context(?blob_service, State#state.account, State#state.param_specs, ReqOptions),
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
-        case Code of
-          ?http_created ->
-            {reply, {ok, acquired}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, acquired);
 
 % List tables
 handle_call({list_tables, Options}, _From, State) ->
@@ -744,12 +664,7 @@ handle_call({new_table, TableName}, _From, State) ->
         ReqContext = new_req_context(?table_service, State#state.account, State#state.param_specs, ReqOptions),
         ReqContext1 = ReqContext#req_context{ content_type = ?json_content_type },
         {Code, Body} = execute_request(ServiceContext, ReqContext1),
-        case Code of
-          ?http_created ->
-            {reply, {ok, created}, State};
-          _ ->
-            {reply, {error, Body}, State}
-        end;
+        return_response(Code, Body, State, ?http_created, created);
 
 % Delete table
 handle_call({delete_table, TableName}, _From, State) ->
@@ -1010,3 +925,11 @@ get_req_common_param_specs() ->
          #param_spec{ id = ?req_param_prefix, type = uri, name = "prefix" },
          #param_spec{ id = ?req_param_include, type = uri, name = "include" },
          #param_spec{ id = ?req_param_marker, type = uri, name = "marker" }].
+
+return_response(Code, Body, State, ExpectedResponseCode, SuccessAtom) ->
+  case Code of
+    ExpectedResponseCode ->
+      {reply, {ok, SuccessAtom}, State};
+    _ ->
+      {reply, {error, Body}, State}
+  end.


### PR DESCRIPTION
Hi, I am using this library for an Elixir application and I would like to pattern match when an operation fails for whatever reason. I noticed that the `case ... of` pattern for deciding on the response is only used on a few of the existing requests. I simply extended this handling of the response to more of the create/update/acquire/delete operations.

Thanks.