### PR TITLE
Fixes error when blob is not found

### DIFF
--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -556,6 +556,7 @@ handle_call({get_blob, Container, Blob, Options}, _From, State) ->
             {reply, {ok, Body}, State};
           ?http_partial_content->
             {reply, {ok, Body}, State}
+          _ -> {reply, {error, Body}, State}            
         end;
 
 % Snapshot blob

--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -555,7 +555,7 @@ handle_call({get_blob, Container, Blob, Options}, _From, State) ->
           ?http_ok ->
             {reply, {ok, Body}, State};
           ?http_partial_content->
-            {reply, {ok, Body}, State}
+            {reply, {ok, Body}, State};
           _ -> {reply, {error, Body}, State}            
         end;
 


### PR DESCRIPTION
Hello !

During the development of my application, I faced an issue when the file does not exist in storage account and I try an ```:erlazure.get_blob```.

Original error:
```bash
[error] GenServer #PID<0.960.0> terminating
** (CaseClauseError) no case clause matching: :error
    (erlazure) /Users/brunocouto/Documents/GitHub/sim-elixir-upload-photo/deps/erlazure/src/erlazure.erl:554: :erlazure.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

I'm new to elixir and i'm not sure if this is the best solution. Any help will be appreciated !