### PR TITLE
Calculate the content-length correctly

### DIFF
--- a/src/erlazure_http.erl
+++ b/src/erlazure_http.erl
@@ -66,7 +66,7 @@ construct_url(ReqContext = #req_context{}) ->
         lists:foldl(FoldFun, "", ReqContext#req_context.parameters).
 
 get_content_length(Content) when is_list(Content) ->
-        lists:flatlength(Content);
+        erlang:iolist_size(Content);
 
 get_content_length(Content) when is_binary(Content) ->
         byte_size(Content).


### PR DESCRIPTION
`lists:flatlength/1` does not return the correct size if the iolist
has binaries.  Use `erlang:iolist_size/1` instead.
e.g.

```
lists:flatlength([<<"a">>, [<<"bc">>]]).
2

erlang:iolist_size([<<"a">>, [<<"bc">>]]).
3
```

This wasn't an issue before as Azure ignored the content-length and things just worked but recently it looks like they will throw errors if the content-length does not match the size of the payload.