### PR TITLE
Use HTTPS instead of `git://` protocol

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-  {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", "main"}}
+  {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", "main"}}
 ]}.
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.


### PR DESCRIPTION
Github has removed support of the unauthenticated/unencrypted `git://`
protocol in favour of encrypted protocols.

See https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git