### PR TITLE
Implement `put_append_blob` and `append_block` ops, bump MS API version, handle `httpc` errors, pin `jsx` version

### DIFF
--- a/include/erlazure.hrl
+++ b/include/erlazure.hrl
@@ -31,7 +31,7 @@
 -define(http_created, 201).
 -define(http_accepted, 202).
 -define(http_no_content, 204).
--define(http_partial_content, 206). 
+-define(http_partial_content, 206).
 
 -define(blob_service, blob).
 -define(table_service, table).
@@ -39,7 +39,7 @@
 -define(file_service, file).
 
 -define(queue_service_ver, "2014-02-14").
--define(blob_service_ver, "2014-02-14").
+-define(blob_service_ver, "2024-05-04").
 -define(table_service_ver, "2014-02-14").
 -define(file_service_ver, "2014-02-14").
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-  {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", "main"}}
+  {jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "v3.1.0"}}}
 ]}.
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.

--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -592,7 +592,11 @@ handle_call({put_blob, Container, Name, Type = append_blob, Options}, _From, Sta
         ReqOptions = [{method, put},
                       {path, lists:concat([Container, "/", Name])},
                       {params, Params ++ Options}],
-        ReqContext = new_req_context(?blob_service, ReqOptions, State),
+        ReqContext1 = new_req_context(?blob_service, ReqOptions, State),
+        ReqContext = case proplists:get_value(content_type, Options) of
+                       undefined    -> ReqContext1#req_context{ content_type = "application/octet-stream" };
+                       ContentType  -> ReqContext1#req_context{ content_type = ContentType }
+                     end,
 
         {Code, Body} = execute_request(ServiceContext, ReqContext),
         return_response(Code, Body, State, ?http_created, created);

--- a/src/erlazure_blob.erl
+++ b/src/erlazure_blob.erl
@@ -166,9 +166,11 @@ parse_block(#xmlElement{ content = Content }, Type) ->
         lists:foldl(FoldFun, #blob_block{ type = Type }, Nodes).
 
 str_to_blob_type("BlockBlob") -> block_blob;
+str_to_blob_type("AppendBlob") -> append_blob;
 str_to_blob_type("PageBlob") -> page_blob.
 
 blob_type_to_str(block_blob) -> "BlockBlob";
+blob_type_to_str(append_blob) -> "AppendBlob";
 blob_type_to_str(page_blob) -> "PageBlob".
 
 block_type_to_node(uncommitted) -> 'Uncommitted';

--- a/src/erlazure_blob.erl
+++ b/src/erlazure_blob.erl
@@ -188,7 +188,11 @@ get_request_body(BlockRefs) ->
         FoldFun = fun(BlockRef=#blob_block{}, Acc) ->
                       [{block_type_to_node(BlockRef#blob_block.type),
                         [],
-                        [base64:encode_to_string(BlockRef#blob_block.id)]} | Acc]
+                        [base64:encode_to_string(BlockRef#blob_block.id)]} | Acc];
+                     ({BlockId, BlockType}, Acc) ->
+                      [{block_type_to_node(BlockType),
+                        [],
+                        [base64:encode_to_string(BlockId)]} | Acc]
                   end,
         Data = {'BlockList', [], lists:reverse(lists:foldl(FoldFun, [], BlockRefs))},
         lists:flatten(xmerl:export_simple([Data], xmerl_xml)).

--- a/test/erlazure_SUITE.erl
+++ b/test/erlazure_SUITE.erl
@@ -149,3 +149,16 @@ t_append_blob_smoke_test(Config) ->
     %% Delete container
     ?assertMatch({ok, deleted}, erlazure:delete_container(Pid, Container)),
     ok.
+
+%% Test error handling when endpoint is unavailable
+t_blob_failure_to_connect(_Config) ->
+    BadEndpoint = "http://127.0.0.2:65535/",
+    {ok, Pid} = erlazure:start(#{account => ?ACCOUNT, key => ?KEY, endpoint => BadEndpoint}),
+    ?assertMatch({error, {failed_connect, _}}, erlazure:list_containers(Pid)),
+    ?assertMatch({error, {failed_connect, _}}, erlazure:create_container(Pid, "c")),
+    ?assertMatch({error, {failed_connect, _}}, erlazure:delete_container(Pid, "c")),
+    ?assertMatch({error, {failed_connect, _}}, erlazure:put_append_blob(Pid, "c", "b1")),
+    ?assertMatch({error, {failed_connect, _}}, erlazure:put_block_blob(Pid, "c", "b1", <<"a">>)),
+    ?assertMatch({error, {failed_connect, _}}, erlazure:append_block(Pid, "c", "b1", <<"a">>)),
+    ?assertMatch({error, {failed_connect, _}}, erlazure:get_blob(Pid, "c", "b1")),
+    ok.


### PR DESCRIPTION
- Pin `jsx` version to avoid unwanted breaking changes.
- Implement `put_append_blob` and `append_block` operations.
- Update MS API version for blob storage.
- Handle `httpc` errors without crashing.
- Fix: correctly encode and sign block ids in `put_block_blob`
- Allow specifying content type in `put_block_list`